### PR TITLE
FIX: UTF-8 encoding in setup.py for Win64 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 def readme():
-    with open('README.md') as f:
+    with open('README.md', encoding='UTF8') as f:
         return f.read()
 
 setup(name='pyfsig',


### PR DESCRIPTION
On Win64, the setup.py may read the readme.md file with the default encoding. I suggest to set it by default to UTF8