### PR TITLE
fix empty header error

### DIFF
--- a/src/pyfsig/file_signatures.py
+++ b/src/pyfsig/file_signatures.py
@@ -1480,6 +1480,9 @@ class Signature(dict):
 def compare_sig(file_header, test_hex_string) -> bool:
     file_header = list(file_header)
 
+    if not file_header:
+        return False
+
     test_hex: List[Optional[int]] = []
     for _byte in test_hex_string.strip().split(" "):
         if _byte != "nn":


### PR DESCRIPTION
In case the file is empty header is empty.
This can is not handled and following exception is raised:

```
File "file_signatures.py", line 1493, in compare_sig
    if _byte != file_header[_loc]:
IndexError: list index out of range

```
This can be reproduced by calling 
`Matches(header=[])`

This PR takes fixes that